### PR TITLE
added config notes for apache 2.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -442,10 +442,13 @@ server {
         SSLEngine on
         SSLCertificateFile    /etc/ssl/certs/chained.pem
         SSLCertificateKeyFile /etc/ssl/private/domain.key
+        ###SSLCertificateChainFile setting needed for Apache 2.2 to avoid "Chain Issues: Incomplete" on SSL test
+        ###SSLCertificateChainFile /etc/ssl/certs/chained.pem
         SSLProtocol all -SSLv2 -SSLv3
         SSlCipherSuite ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA;
         SSLHonorCipherOrder on
         SSLOpenSSLConfCmd DHParameters "/etc/ssl/certs/dhparam.pem"
+        ### SSLOpenSSLConfCmd not supported in Apache 2.2, instead append dhparam.pem to chained.pem
         &lt;Directory /var/www/foo.com/html&gt;
                 Options Indexes FollowSymLinks MultiViews
                 AllowOverride All


### PR DESCRIPTION
`SSLCertificateChainFile` parameter for chained certificate for apache 2.2, otherwise, SSL test returns "Chain issues: Incomplete"

`SSLOpenSSLConfCmd` parameter not available in 2.2,
instead, according to this page regarding logjam vulnerability

https://weakdh.org/sysadmin.html#apache

> If you are using Apache with LibreSSL, or Apache 2.4.7 and OpenSSL 0.9.8a or later, you can append the DHparams you generated earlier to the end of your certificate file.

just append the `dhparam.pem` to the end of the certificate file.
