### PR TITLE
fix incorrect sni alerts warning for apache config

### DIFF
--- a/index.html
+++ b/index.html
@@ -437,7 +437,7 @@ server {
 <pre>
 &lt;VirtualHost _default_:443&gt;
         ServerName foo.com:443
-        ServerAlias www.foo.com:443
+        ServerAlias www.foo.com
         DocumentRoot /var/www/foo.com/html
         SSLEngine on
         SSLCertificateFile    /etc/ssl/certs/chained.pem


### PR DESCRIPTION
fixes #32 

if the `:443` port number is included in the `ServerAlias` setting,
i got an error for the `Incorrect SNI alerts` parameter of the
`Protocol Details` section of the SSL Labs ssl server test.

simply removing the port number fixes the error for apache 2.2
at least, i don't have 2.4 to test
