### PR TITLE
Fix fail debug check

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -43,7 +43,7 @@ var //CA = "https://acme-staging.api.letsencrypt.org",
 
 // debug console output on failure
 function failConsole(){
-    if(window.location.search.contains("debug") && console){
+    if(window.location.search.indexOf("debug") !== -1 && console){
         console.log("ACCOUNT_EMAIL", ACCOUNT_EMAIL);
         console.log("ACCOUNT_PUBKEY", JSON.stringify(ACCOUNT_PUBKEY));
         console.log("CSR", JSON.stringify(CSR));


### PR DESCRIPTION
Currently this error is thrown in Step 4 upon failure: `Uncaught TypeError: window.location.search.contains is not a function`

I believe this was meant to be https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes, which isn't the most compatible. This should help.
