### PR TITLE
Update index.html to include missing li close tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -340,6 +340,7 @@ openssl req -new -sha256 -key domain.key -subj "/" \
                                 Create the ".well-known/acme-challenge/" directory
                                 in your webserver's static file path:<br/>
                                 <pre class="wwwdir">mkdir -p /path/to/www/.well-known/acme-challenge/</pre>
+                            </li>
                             <li>
                                 Add the static folder to your webserver's config
                                 (if you haven't already):<br/>


### PR DESCRIPTION
On line 343, there is a missing close tag to the open li tag on line 339.
